### PR TITLE
fixed cohesion functie na 2 uur gekut met git gvd

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,9 +2,9 @@ from Evolutionary import EA
 import os
 
 ### Hyperparameters
-pop_size = 50
+pop_size = 40
 layer_sizes = [4, 4, 3, 1]
-num_generations = 100
+num_generations = 50
 mutation_rate = 0.10
 mutation_step = 0.10
 tournament_size = 2

--- a/simulation.py
+++ b/simulation.py
@@ -10,8 +10,8 @@ import os
 
 
 # Define constants
-WIDTH = 450
-HEIGHT = 450
+WIDTH = 600
+HEIGHT = 600
 WALL_MARGIN = 50
 NUM_AGENTS = 15
 AGENT_SIZE = 5


### PR DESCRIPTION
Cohesion score wordt nu berekend door cohesion^2 * 20 waardoor de alignment en cohesion normalized zijn naar de 0.60. Ik heb  nog wat print statements toegevoegd om te kijken hoe het gemiddeld gaat en niet alleen de fittest individual. 

Ik heb echt 2 uur gekut met github want ik had een json file meegegeven die te groot was voor github dus ik kreeg een error, maar toen ik hem had verwijderd bleef de error omdat het nog in mijn commit history stond en heb dat ook verwijderd met hulp van chatgpt, maar daar was git het blijkbaar niet mee eens, dus heb ik de hele repository verwijderd van mijn computer en opnieuw git clone gedaan en de files toegevoegd die ik had veranderd. Geen gelogde json files meegeven dus :)))